### PR TITLE
Move moderator_groups definition to fix HasManyThroughOrderError

### DIFF
--- a/app/models/forem/forum.rb
+++ b/app/models/forem/forum.rb
@@ -10,9 +10,9 @@ module Forem
     belongs_to :category
 
     has_many :topics,     :dependent => :destroy
+    has_many :moderator_groups
     has_many :posts,      :through => :topics, :dependent => :destroy
     has_many :moderators, :through => :moderator_groups, :source => :group
-    has_many :moderator_groups
 
     validates :category, :name, :description, :presence => true
 


### PR DESCRIPTION
Move moderator_groups definition in forum model to fix ActiveRecord::HasManyThroughOrderError